### PR TITLE
Support checkbox in native json

### DIFF
--- a/tests/test_xlson.py
+++ b/tests/test_xlson.py
@@ -255,9 +255,16 @@ class TestXLSon(PyxformMarkdown, unittest.TestCase):
             "label": "Choose colours you like?",
             "type": "select all that apply",
             "children": [
-                {"name": "red", "label": "REd"},
-                {"name": "green", "label": "Green"},
-                {"name": "yellow", "label": "Yellow"},
+                {
+                    "name": "ze_gree",
+                    "label": "Green",
+                    "instance": {"openmrs_entity_id": "AABBGRR"},
+                },
+                {
+                    "name": "ze_yellow",
+                    "label": "Yellow",
+                    "instance": {"openmrs_entity_id": "BBCCYLL"},
+                },
             ],
         }
         selected = False
@@ -265,108 +272,25 @@ class TestXLSon(PyxformMarkdown, unittest.TestCase):
             xlson.build_field(options),
             {
                 "key": "colours",
-                "openmrs_choice_ids": {},
                 "openmrs_entity_parent": "",
                 "openmrs_entity": "",
                 "openmrs_entity_id": "",
-                "type": "checkbox",
+                "type": "check_box",
                 "label": "Choose colours you like?",
-                 "options": [
+                "options": [
                     {
-                        "key": "red",
-                        "text": "Red",
-                        "value": selected,
-                        "openmrs_choice_id": ""
-                    },
-                    {
-                        "key": "green",
+                        "key": "ze_gree",
                         "text": "Green",
-                        "value": selected,
-                        "openmrs_choice_id": "",
+                        "openmrs_choice_id": "AABBGRR",
+                        "value": selected
                     },
                     {
-                        "key": "yellow",
+                        "key": "ze_yellow",
                         "text": "Yellow",
-                        "value": selected,
-                        "openmrs_choice_id": "",
+                        "openmrs_choice_id": "BBCCYLL",
+                        "value": selected
                     }
                 ]
-            },  # noqa
-        )
-
-    def test_spinner_field(self) -> None:
-        """Test xlson.build_field() - returns a native form spinner field dict."""
-        # Without openmrs_entity_id
-        options = {
-            "name": "user_spinner",
-            "label": "What is the mood?",
-            "type": "select all that apply",
-            "children": [
-                {"name": "happy", "label": "Happy"},
-                {"name": "sad", "label": "Sad"},
-                {"name": "somber", "label": "Somber"},
-            ],
-        }
-        self.assertDictEqual(
-            xlson.build_field(options),
-            {
-                "key": "user_spinner",
-                "openmrs_choice_ids": {},
-                "openmrs_entity_parent": "",
-                "openmrs_entity": "",
-                "openmrs_entity_id": "",
-                "type": "spinner",
-                "hint": "What is the mood?",
-                "values": ["Happy", "Sad", "Somber"],
-                "keys": ["happy", "sad", "somber"],
-            },  # noqa
-        )
-
-        # With openmrs_entity_id
-        options = {
-            "name": "user_spinner",
-            "label": "What is the mood?",
-            "type": "select all that apply",
-            "children": [
-                {
-                    "name": "happy",
-                    "label": "Happy",
-                    "instance": {
-                        "openmrs_entity_id": "1107AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                    },
-                },
-                {
-                    "name": "sad",
-                    "label": "Sad",
-                    "instance": {
-                        "openmrs_entity_id": "1713AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                    },
-                },
-                {
-                    "name": "somber",
-                    "label": "Somber",
-                    "instance": {
-                        "openmrs_entity_id": "2113AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                    },
-                },
-            ],
-        }
-        self.assertDictEqual(
-            xlson.build_field(options),
-            {
-                "key": "user_spinner",
-                "openmrs_entity_parent": "",
-                "openmrs_entity": "",
-                "openmrs_entity_id": "",
-                "type": "spinner",
-                "hint": "What is the mood?",
-                "values": ["Happy", "Sad", "Somber"],
-                "keys": ["happy", "sad", "somber"],
-                "openmrs_choice_ids": {
-                    "happy": "1107AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                    "sad": "1713AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                    "somber": "2113AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                },
             },  # noqa
         )
 

--- a/tests/test_xlson.py
+++ b/tests/test_xlson.py
@@ -282,15 +282,15 @@ class TestXLSon(PyxformMarkdown, unittest.TestCase):
                         "key": "ze_gree",
                         "text": "Green",
                         "openmrs_choice_id": "AABBGRR",
-                        "value": selected
+                        "value": selected,
                     },
                     {
                         "key": "ze_yellow",
                         "text": "Yellow",
                         "openmrs_choice_id": "BBCCYLL",
-                        "value": selected
-                    }
-                ]
+                        "value": selected,
+                    },
+                ],
             },  # noqa
         )
 

--- a/tests/test_xlson.py
+++ b/tests/test_xlson.py
@@ -247,6 +247,53 @@ class TestXLSon(PyxformMarkdown, unittest.TestCase):
             },
         )
 
+    def test_checkbox_field(self) -> None:
+        """Test xlson.build_field() - returns a native form checkbox field dict."""
+        # Without openmrs_entity_id
+        options = {
+            "name": "colours",
+            "label": "Choose colours you like?",
+            "type": "select all that apply",
+            "children": [
+                {"name": "red", "label": "REd"},
+                {"name": "green", "label": "Green"},
+                {"name": "yellow", "label": "Yellow"},
+            ],
+        }
+        selected = False
+        self.assertDictEqual(
+            xlson.build_field(options),
+            {
+                "key": "colours",
+                "openmrs_choice_ids": {},
+                "openmrs_entity_parent": "",
+                "openmrs_entity": "",
+                "openmrs_entity_id": "",
+                "type": "checkbox",
+                "label": "Choose colours you like?",
+                 "options": [
+                    {
+                        "key": "red",
+                        "text": "Red",
+                        "value": selected,
+                        "openmrs_choice_id": ""
+                    },
+                    {
+                        "key": "green",
+                        "text": "Green",
+                        "value": selected,
+                        "openmrs_choice_id": "",
+                    },
+                    {
+                        "key": "yellow",
+                        "text": "Yellow",
+                        "value": selected,
+                        "openmrs_choice_id": "",
+                    }
+                ]
+            },  # noqa
+        )
+
     def test_spinner_field(self) -> None:
         """Test xlson.build_field() - returns a native form spinner field dict."""
         # Without openmrs_entity_id

--- a/xlson/__init__.py
+++ b/xlson/__init__.py
@@ -211,6 +211,7 @@ class NativeRadioField(NativeFormField):
 
         super(NativeRadioField, self).__init__(**params)
 
+
 class CheckboxField(NativeFormField):
     """Native form Checkbox Field (Multi-select field)."""
 
@@ -238,6 +239,7 @@ class CheckboxField(NativeFormField):
             params.pop("children")
 
         super(CheckboxField, self).__init__(**params)
+
 
 class Step(dict):
     """Native form step section."""

--- a/xlson/__init__.py
+++ b/xlson/__init__.py
@@ -20,6 +20,7 @@ KEY = "key"
 LABEL = "label"
 NAME = "name"
 OPENMRS_ENTITY_ID = "openmrs_entity_id"
+OPENMRS_CHOICE_ID = "openmrs_choice_id"
 TITLE = "title"
 TYPE = "type"
 CONSTRAINT = "constraint"
@@ -210,34 +211,33 @@ class NativeRadioField(NativeFormField):
 
         super(NativeRadioField, self).__init__(**params)
 
+class CheckboxField(NativeFormField):
+    """Native form Checkbox Field (Multi-select field)."""
 
-class SpinnerField(NativeFormField):
-    """Native form spinner field."""
-
-    field_type: str = "spinner"
+    field_type: str = "check_box"
 
     FIELDS = NativeFormField.FIELDS.copy()
-    FIELDS.update({"values": str, "keys": str, "openmrs_choice_ids": str, "hint": str})
+    FIELDS.update({"label": str, "options": str})
 
     def __init__(self, **kwargs: Dict) -> None:
         assert LABEL in kwargs, "'%s' is a required field." % LABEL
         assert CHILDREN in kwargs, "'%s' is a required field." % CHILDREN
         params: Dict[str, Any] = kwargs.copy()
-        params[HINT] = params.pop(LABEL)
 
-        params["keys"] = [child["name"] for child in params[CHILDREN]]
-        params["values"] = [child["label"] for child in params[CHILDREN]]
-        choice_ids_options = [
-            child[INSTANCE][OPENMRS_ENTITY_ID]
-            for child in params[CHILDREN]
-            if INSTANCE in child and OPENMRS_ENTITY_ID in child[INSTANCE]
-        ]
-        params["openmrs_choice_ids"] = {
-            k: v for k, v in zip(params["keys"], choice_ids_options)
-        }
+        if CHILDREN in params:
+            selected = False
+            params["options"] = []
+            for child in params[CHILDREN]:
+                options_data = {
+                    "key": child["name"],
+                    OPENMRS_CHOICE_ID: child[INSTANCE][OPENMRS_ENTITY_ID],
+                    "text": child["label"],
+                    "value": selected,
+                }
+                params["options"].append(options_data)
+            params.pop("children")
 
-        super(SpinnerField, self).__init__(**params)
-
+        super(CheckboxField, self).__init__(**params)
 
 class Step(dict):
     """Native form step section."""
@@ -274,7 +274,7 @@ def build_field(options: Dict) -> Dict:
     elif options[TYPE] == QuestionTypes.SELECT_ONE.value:
         field = NativeRadioField(**options)
     elif options[TYPE] == QuestionTypes.SELECT_MULTIPLE.value:
-        field = SpinnerField(**options)
+        field = CheckboxField(**options)
 
     return field
 


### PR DESCRIPTION
- Fix Select-Multiple XLSForm entries to generate Checkbox JSON field type instead of Spinner
- See https://github.com/OpenSRP/xlson/issues/41 for details. 