### PR TITLE
Include support for select one widgets

### DIFF
--- a/tests/test_xlson.py
+++ b/tests/test_xlson.py
@@ -222,6 +222,72 @@ class TestXLSon(PyxformMarkdown, unittest.TestCase):
             },  # noqa
         )
 
+    def test_spinner_field(self) -> None:
+        """Test xlson.build_field() - returns a native form spinner field dict."""
+        options = {
+            "name": "user_spinner",
+            "label": "What is the mood?",
+            "type": "select one",
+            "hint": "What is the mood?",
+            "children": [
+                {
+                    "name": "happy",
+                    "label": "Happy",
+                    "instance": {
+                        "openmrs_entity_id": "1107AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                    },
+                },
+                {
+                    "name": "sad",
+                    "label": "Sad",
+                    "instance": {
+                        "openmrs_entity_id": "1713AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                    },
+                },
+                {
+                    "name": "somber",
+                    "label": "Somber",
+                    "instance": {
+                        "openmrs_entity_id": "2113AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                    },
+                },
+            ],
+        }  # noqa
+        self.assertDictEqual(
+            xlson.build_field(options),
+            {
+                "key": "user_spinner",
+                "openmrs_entity_parent": "",
+                "openmrs_entity": "",
+                "openmrs_entity_id": "",
+                "type": "spinner",
+                "hint": "What is the mood?",
+                "options": [
+                    {
+                        "key": "happy",
+                        "openmrs_entity_parent": "",
+                        "openmrs_entity": "",
+                        "openmrs_entity_id": "1107AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "text": "Happy",
+                    },
+                    {
+                        "key": "sad",
+                        "openmrs_entity_parent": "",
+                        "openmrs_entity": "",
+                        "openmrs_entity_id": "1713AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "text": "Sad",
+                    },
+                    {
+                        "key": "somber",
+                        "openmrs_entity_parent": "",
+                        "openmrs_entity": "",
+                        "openmrs_entity_id": "2113AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "text": "Somber",
+                    },
+                ],
+            },  # noqa
+        )
+
     def test_required_field(self) -> None:
         """Test xlson.build_field() - returns a native form required field dict."""
         options = {

--- a/xlson/__init__.py
+++ b/xlson/__init__.py
@@ -183,18 +183,25 @@ class BarcodeField(NativeFormField):
         super(BarcodeField, self).__init__(**params)
 
 
-class NativeRadioField(NativeFormField):
-    """Native form native radio field."""
-
-    field_type: str = "native_radio"
-
-    FIELDS = NativeFormField.FIELDS.copy()
-    FIELDS.update({"label": str, "options": str})
+class SelectOneField(NativeFormField):
+    """
+    Native form native radio field
+    Spinner native radio field
+    """
 
     def __init__(self, **kwargs: Dict) -> None:
+        self.FIELDS = NativeFormField.FIELDS.copy()  # pylint: disable=C0103
+        self.FIELDS.update({"label": str, "options": str, "hint": str})
         assert LABEL in kwargs, "'%s' is a required field." % LABEL
         assert CHILDREN in kwargs, "'%s' is a required field." % CHILDREN
         params: Dict[str, Any] = kwargs.copy()
+
+        if HINT in params.keys():
+            self.field_type: str = "spinner"
+            self.FIELDS.pop(LABEL)
+        else:
+            self.field_type: str = "native_radio"
+            self.FIELDS.pop(HINT)
 
         if CHILDREN in params:
             params["options"] = []
@@ -209,7 +216,7 @@ class NativeRadioField(NativeFormField):
                 params["options"].append(options_data)
             params.pop("children")
 
-        super(NativeRadioField, self).__init__(**params)
+        super(SelectOneField, self).__init__(**params)
 
 
 class CheckboxField(NativeFormField):
@@ -274,7 +281,7 @@ def build_field(options: Dict) -> Dict:
     elif options[TYPE] == QuestionTypes.BARCODE.value:
         field = BarcodeField(**options)
     elif options[TYPE] == QuestionTypes.SELECT_ONE.value:
-        field = NativeRadioField(**options)
+        field = SelectOneField(**options)
     elif options[TYPE] == QuestionTypes.SELECT_MULTIPLE.value:
         field = CheckboxField(**options)
 


### PR DESCRIPTION
Native radio widgets and the spinner widget both resonate with XLSForms select_one question type.
This implementation allows conversion of both native radio and spinner widgets to their respective native json representation.
Resolves #20 